### PR TITLE
Change 'always thread' behavior to 'thread if in thread' behavior

### DIFF
--- a/lisa_commands/lambda_function.py
+++ b/lisa_commands/lambda_function.py
@@ -30,8 +30,8 @@ def lambda_handler(data, _context):
             'channel': slack_event["channel"],
             'text': get_return_text(slack_event['text'], slack_event['user'])
         }
-        if 'ts' in slack_event:
-            data['thread_ts'] = slack_event['ts']
+        if 'thread_ts' in slack_event:
+            data['thread_ts'] = slack_event['thread_ts']
     # Currently the emoji that causes the delete logic is 'delet' (Yes it's mispelled)
     elif 'reaction_added' in slack_event['type'] and 'delet' in slack_event["reaction"]:
         chat_action = 'chat.delete'


### PR DESCRIPTION
Alright, pretty sure i have it right this time. I confused myself with how i had some variables named in renwick. What i WAS doing was creating a thread EVERY TIME by using the timestamp of the message, not the optionally included thread_ts payload item. 

This is outlined in the doc here: 
![Screen Shot 2019-08-15 at 10 09 49 AM](https://user-images.githubusercontent.com/1924444/63104572-da243c80-bf44-11e9-99d4-bda80990ab74.png)

Source: https://api.slack.com/docs/message-threading
