### PR TITLE
#58: add new, more intuitive syntax for spotify commands

### DIFF
--- a/lisa_commands/commands.py
+++ b/lisa_commands/commands.py
@@ -113,7 +113,32 @@ def commands():
                 spotify me track Snow Halation
                 spotify me album The Life of Pablo
                 spotify me artist Streetlight Manifesto
+                spotify me playlist Today's Top Hits
             """
+        },
+        'song me': {
+          'function': song_me,
+            "description": """
+            Shortcut for 'spotify me track.'
+            """
+        },
+        'album me': {
+            'function': album_me,
+            "description": """
+        Shortcut for 'spotify me album.'
+        """
+        },
+        'artist me': {
+            'function': artist_me,
+            "description": """
+        Shortcut for 'spotify me artist.'
+        """
+        },
+        'playlist me': {
+            'function': playlist_me,
+            "description": """
+        Shortcut for 'spotify me playlist.'
+        """
         },
         'sticker me': {
             'function': sticker_me,
@@ -509,6 +534,38 @@ def spotify_me(query, _slack_event):
     Returns a link to spotify media item found by search
     """
     return request.spotify_search(query)
+
+def song_me(query, _slack_event):
+    """
+    :param query: query str
+    :param _slack_event: a dict of slack event information(unused for this function)
+    :return: a link to spotify song item found by search
+    """
+    return request.spotify_query('track', query)
+
+def album_me(query, _slack_event):
+    """
+    :param query: query str
+    :param _slack_event: a dict of slack event information(unused for this function)
+    :return: a link to spotify album item found by search
+    """
+    return request.spotify_query('album', query)
+
+def artist_me(query, _slack_event):
+    """
+    :param query: query str
+    :param _slack_event: a dict of slack event information(unused for this function)
+    :return: a link to spotify artist item found by search
+    """
+    return request.spotify_query('artist', query)
+
+def playlist_me(query, _slack_event):
+    """
+    :param query: query str
+    :param _slack_event: a dict of slack event information(unused for this function)
+    :return: a link to spotify playlist item found by search
+    """
+    return request.spotify_query('playlist', query)
 
 def sticker_me(query, _slack_event):
     """

--- a/lisa_commands/commands.py
+++ b/lisa_commands/commands.py
@@ -528,8 +528,10 @@ def shame(query, slack_event):
 
 def spotify_me(query, _slack_event, query_type=None):
     """
-    query - query str
-    slack_event - A dict of slack event information(unused for this function)
+    :param query: query str
+    :param _slack_event: A dict of slack event information(unused for this function)
+    :param query_type: An optional string used for passing in the query type of the spotify search (song, album, artist,
+    playlist). If no query type is passed, the query type will be parsed used the first word of the query.
 
     Returns a link to spotify media item found by search
     """

--- a/lisa_commands/commands.py
+++ b/lisa_commands/commands.py
@@ -526,14 +526,22 @@ def shame(query, slack_event):
         {'user': {'S': query}}
     )['Item']['karma']['N']
 
-def spotify_me(query, _slack_event):
+def spotify_me(query, _slack_event, query_type=None):
     """
     query - query str
     slack_event - A dict of slack event information(unused for this function)
 
     Returns a link to spotify media item found by search
     """
-    return request.spotify_search(query)
+    if query_type is None:
+        query_type, search_query = query.split(' ', 1)
+    else:
+        search_query = query
+
+    query_types = ['track', 'album', 'artist', 'playlist']
+    if query_type not in query_types:
+        return f'Invalid Media Type for search. Valid types are {" ".join(query_types)}'
+    return request.spotify_search(query_type, search_query)
 
 def song_me(query, _slack_event):
     """
@@ -541,7 +549,7 @@ def song_me(query, _slack_event):
     :param _slack_event: a dict of slack event information(unused for this function)
     :return: a link to spotify song item found by search
     """
-    return request.spotify_query('track', query)
+    return spotify_me(query, _slack_event, 'track')
 
 def album_me(query, _slack_event):
     """
@@ -549,7 +557,7 @@ def album_me(query, _slack_event):
     :param _slack_event: a dict of slack event information(unused for this function)
     :return: a link to spotify album item found by search
     """
-    return request.spotify_query('album', query)
+    return spotify_me(query, _slack_event, 'album')
 
 def artist_me(query, _slack_event):
     """
@@ -557,7 +565,7 @@ def artist_me(query, _slack_event):
     :param _slack_event: a dict of slack event information(unused for this function)
     :return: a link to spotify artist item found by search
     """
-    return request.spotify_query('artist', query)
+    return spotify_me(query, _slack_event, 'artist')
 
 def playlist_me(query, _slack_event):
     """
@@ -565,7 +573,7 @@ def playlist_me(query, _slack_event):
     :param _slack_event: a dict of slack event information(unused for this function)
     :return: a link to spotify playlist item found by search
     """
-    return request.spotify_query('playlist', query)
+    return spotify_me(query, _slack_event, 'playlist')
 
 def sticker_me(query, _slack_event):
     """

--- a/lisa_commands/request_helper.py
+++ b/lisa_commands/request_helper.py
@@ -212,25 +212,12 @@ def gify_search(media_type, query):
 
     return None
 
-def spotify_search(query):
-    """
-    wrapper method for spotify_query in order to maintain support for old 'spotify me' syntax
-    :query what type of content we are querying for and the search terms themselves
-    """
-    query_type, search_query = query.split(' ', 1)
-
-    return spotify_query(query_type, search_query)
-
-def spotify_query(query_type, search_query):
+def spotify_search(query_type, search_query):
     """
     submit a search query to spotify
     :param query_type: the type of query, of track, album, artist, or playlist.
     :param search_query:
     """
-    query_types = ['track', 'album', 'artist', 'playlist']
-    if query_type not in query_types:
-        return f'Invalid Media Type for search. Valid types are { " ".join(query_types) }'
-
     search_params = urllib.parse.urlencode({
         'q': search_query,
         'type': query_type,

--- a/lisa_commands/request_helper.py
+++ b/lisa_commands/request_helper.py
@@ -214,13 +214,20 @@ def gify_search(media_type, query):
 
 def spotify_search(query):
     """
-    submit a search to spotify
+    wrapper method for spotify_query in order to maintain support for old 'spotify me' syntax
     :query what type of content we are querying for and the search terms themselves
     """
-
-    query_types = ['track', 'album', 'artist', 'playlist']
     query_type, search_query = query.split(' ', 1)
 
+    return spotify_query(query_type, search_query)
+
+def spotify_query(query_type, search_query):
+    """
+    submit a search query to spotify
+    :param query_type: the type of query, of track, album, artist, or playlist.
+    :param search_query:
+    """
+    query_types = ['track', 'album', 'artist', 'playlist']
     if query_type not in query_types:
         return f'Invalid Media Type for search. Valid types are { " ".join(query_types) }'
 
@@ -247,8 +254,6 @@ def spotify_search(query):
         return search_response[f'{query_type}s']['items'][0]['external_urls']['spotify']
 
     return None
-
-
 
 def return_status():
     """


### PR DESCRIPTION
Resolves #58 

Adding new syntax for the Spotify commands, as I found the "spotify me [track|album|artist]" syntax to be a bit cumbersome. The original syntax still works.

I also took the liberty of documenting the playlist functionality, as it was present in the original spotify search function but undocumented in the commands list.