### PR TITLE
#26: Add poll me command

### DIFF
--- a/lisa_commands/commands.py
+++ b/lisa_commands/commands.py
@@ -457,14 +457,15 @@ def poll_me(query, slack_event):
     :return: A poll with the given options in the query string
     """
     if len(query) == 0:
-        return "You'll need to ask a question and provide at least two valid options to make a poll."
+        return "You want me to create a poll without giving me a question or options? Give me something to work with here!"
     tokens = query.split(',')
     number_emojis = [":one:", ":two:", ":three:", ":four:", ":five:", ":six:", ":seven:", ":eight:", ":nine:"]
 
-    if len(tokens) <= 2:
-        return "You'll need to ask a question and provide at least two valid options to make a poll."
-
-    if len(tokens) > 10:
+    if len(tokens) == 1:
+        return "Polls aren't open-ended questions, you'll need to provide at least two answer choices!"
+    elif len(tokens) == 2:
+        return "A poll with only one option? Sounds like you've already made up your mind..."
+    elif len(tokens) > 10:
         return "That's too many options, you'll give everyone decision paralysis! Maximum of 9 poll options allowed."
 
     response_text = "POLL: "


### PR DESCRIPTION
Poll Me command. It's super stripped-down compared to Cole's old bot - I don't remember how the poll command syntax worked for Lilly, nor how he added reactions to the bot's own messages to start off the voting. It also won't dynamically add the users' names to the message as they vote. These enhancements would probably be good for a future task.

Another note, I'm doing the syntax as plain old comma-separated values. Not sure if this is the best approach, but my other ideas were weird to try to implement and I'm not sure if there would've really been much better. If any of you have any ideas for better syntax, let me know.

Resolves #26 

EDIT: When I was working on this originally a couple of weeks ago I apparently added in a quick fix for the `@Lisa praise` bug, so this also Resolves #73 